### PR TITLE
cannot write mode P as JPEG

### DIFF
--- a/cropper/models.py
+++ b/cropper/models.py
@@ -27,6 +27,8 @@ class SourceImage(models.Model):
                 preview = original.resize(original.size)
             
             contents = StringIO()
+            if preview.mode != 'RGB':
+                preview = preview.convert('RGB')
             preview.save(contents, format='jpeg', quality=25)
             self.preview.save(
                 '%s.jpg' % str(uuid.uuid4()),


### PR DESCRIPTION
Hi montylounge,

thanks the app, it's really very useful.
There just have been an issue with paletted images:
  If i tried to add a paletted png, i always got this IOError saying
  "cannot write mode P as JPEG".

Some googling and hacking later i found a solution.

It's might not the best one, but at least it makes django_cropper work with this images.

Cheeeeeeeeeeeeers
